### PR TITLE
Cleanups

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,69 +2,64 @@ var fs = require("fs");
 var Handlebars = require("handlebars");
 
 function render(resume) {
+    // Load css and template
+    var css = fs.readFileSync(__dirname + "/css/style.css", "utf-8");
+    var template = fs.readFileSync(__dirname + "/resume.template", "utf-8");
+    // Load print-specific css
+    var print = fs.readFileSync(__dirname + "/css/print.css", "utf-8");
 
-	var css = fs.readFileSync(__dirname + "/css/style.css", "utf-8");
-	var template = fs.readFileSync(__dirname + "/resume.template", "utf-8");
-
-  // Uncomment this for printing as .pdf
-  var print = fs.readFileSync(__dirname + "/css/print.css", "utf-8");
-
-  // http://stackoverflow.com/a/12002281/1263876
-  Handlebars.registerHelper("foreach",function(arr,options) {
-      if(options.inverse && !arr.length)
-          return options.inverse(this);
-
-      return arr.map(function(item,index) {
-          item.$index = index;
-          item.$first = index === 0;
-          item.$notfirst = index !== 0;
-          item.$last  = index === arr.length-1;
-          return options.fn(item);
-      }).join('');
-  });
-
-  // http://stackoverflow.com/a/16315366
-  Handlebars.registerHelper('ifCond', function (v1, operator, v2, options) {
-    switch (operator) {
-        case '==':
-            return (v1 == v2) ? options.fn(this) : options.inverse(this);
-        case '===':
-            return (v1 === v2) ? options.fn(this) : options.inverse(this);
-        case '<':
-            return (v1 < v2) ? options.fn(this) : options.inverse(this);
-        case '<=':
-            return (v1 <= v2) ? options.fn(this) : options.inverse(this);
-        case '>':
-            return (v1 > v2) ? options.fn(this) : options.inverse(this);
-        case '>=':
-            return (v1 >= v2) ? options.fn(this) : options.inverse(this);
-        case '&&':
-            return (v1 && v2) ? options.fn(this) : options.inverse(this);
-        case '||':
-            return (v1 || v2) ? options.fn(this) : options.inverse(this);
-        default:
+    // Register custom handlebars extensions ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // foreach loops //
+    // http://stackoverflow.com/a/12002281/1263876
+    Handlebars.registerHelper("foreach",function(arr,options) {
+        if(options.inverse && !arr.length)
             return options.inverse(this);
-    }
-  });
 
-  // http://stackoverflow.com/a/18831911
-  Handlebars.registerHelper('commalist', function(items, options) {
-    return options.fn(items.join(', '));
-  });
-
-  // return Handlebars.compile(template)({
-  //   css: css,
-  //   resume: resume
-  // });
-
-  //Uncomment this for printing as .pdf
-	return Handlebars.compile(template)({
-		css: css,
-    print: print,
-		resume: resume
-	});
+        return arr.map(function(item,index) {
+            item.$index = index;
+            item.$first = index === 0;
+            item.$notfirst = index !== 0;
+            item.$last  = index === arr.length-1;
+            return options.fn(item);
+        }).join('');
+    });
+    // Logic operators //
+    // http://stackoverflow.com/a/16315366
+    Handlebars.registerHelper('ifCond', function (v1, operator, v2, options) {
+        switch (operator) {
+            case '==':
+                return (v1 == v2) ? options.fn(this) : options.inverse(this);
+            case '===':
+                return (v1 === v2) ? options.fn(this) : options.inverse(this);
+            case '<':
+                return (v1 < v2) ? options.fn(this) : options.inverse(this);
+            case '<=':
+                return (v1 <= v2) ? options.fn(this) : options.inverse(this);
+            case '>':
+                return (v1 > v2) ? options.fn(this) : options.inverse(this);
+            case '>=':
+                return (v1 >= v2) ? options.fn(this) : options.inverse(this);
+            case '&&':
+                return (v1 && v2) ? options.fn(this) : options.inverse(this);
+            case '||':
+                return (v1 || v2) ? options.fn(this) : options.inverse(this);
+            default:
+                return options.inverse(this);
+        }
+    });
+    // comma separated lists //
+    // http://stackoverflow.com/a/18831911
+    Handlebars.registerHelper('commalist', function(items, options) {
+        return options.fn(items.join(', '));
+    });
+    // Compile
+    return Handlebars.compile(template)({
+        css: css,
+        print: print,
+        resume: resume
+    });
 }
 
 module.exports = {
-	render: render
+    render: render
 };

--- a/resume.template
+++ b/resume.template
@@ -164,13 +164,17 @@
                         {{else}}
                           <p>
                         {{/if}}
-                        {{#if website}}
+                        {{#ifCond website '&&' company}}
                           <strong>{{position}}</strong>
-                          {{#if company.length}} at <strong><a href="{{website}}">{{company}}:</a></strong> {{/if}}
+                          at <strong><a href="{{website}}">{{company}}:</a></strong>
                         {{else}}
-                          <strong>{{position}}</strong>
-                          {{#if company.length}} at <strong>{{company}}:</strong> {{/if}}
-                        {{/if}}
+                          {{#if company.length}}
+                            <strong>{{position}}</strong>
+                            at <strong>{{company}}:</strong>
+                          {{else}}
+                            <strong>{{position}}:</strong>
+                          {{/if}}
+                        {{/ifCond}}
                         </p>
                       {{/ifCond}}
                       {{#if summary}}

--- a/resume.template
+++ b/resume.template
@@ -1,402 +1,344 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-	<head>
-	
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, user-scalable=no, minimal-ui">
-	
-	<title>{{#resume.basics}}{{name}}{{/resume.basics}}</title>
-	<link href='http://fonts.googleapis.com/css?family=Merriweather:400,300,700' rel='stylesheet' type='text/css'>
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-	
-
-	<style>
-	{{{css}}}
-	</style>
-
-	<style media="print">
-	{{{print}}}
-	</style>
-	
-	</head>
-	<body>
-
-		<div class="resume-wrapper">
-		  <article class="paper">
-		  	{{#resume.basics}}
-			    <header>
-			      <div class="header-content">
-			      	{{#if picture}}
-			        <div class="header-pic" title="Wiggle Wiggle">
-			          <img src="{{picture}}" class="pic" />
-			        </div>
-			        {{/if}}
-			        <div class="header-text">
-			          <p>
-			            {{name}}
-			          </p>
-			          <p class="subtitle">{{label}}</p>
-			        </div>
-			      </div>
-			    </header>
-			    <div class="content-wrapper">
-			    
-			      <!-- CONTACT -->
-			      <section class="content">
-			        <div class="row">
-			          <div class="content-cat">
-			           Contact
-			          </div>
-			          <div class="content-text">
-			          	{{#if website}}
-				            <ul>
-				              <li>Website</li>
-				              <li>{{website}}</li>
-				            </ul>
-			            {{/if}}
-
-			            {{#if email}}
-				            <ul>
-				              <li>Email</li>
-				              <li>{{email}}</li>
-				            </ul>
-			            {{/if}}
-
-			            {{#if phone}}
-				            <ul>
-				              <li>Phone</li>
-				              <li>{{phone}}</li>
-				            </ul>
-			            {{/if}}
-			          </div>
-			        </div>
-			      </section>
-
-			      <!-- LOCATION -->
-			      {{#location}}
-				      {{#ifCond address '||' city}}
-					      <section class="content">
-					        <div class="row">
-					          <div class="content-cat">
-					           Location
-					          </div>
-					          <div class="content-text">
-
-					          	{{#if address}}
-						            <ul>
-						              <li>Address</li>
-						              <li>{{address}}</li>
-						            </ul>
-					            {{/if}}
-
-					            {{#if city}}
-					            	{{#if postalCode}}
-							            <ul>
-							              <li>Postal Code & City</li>
-							              <li>{{postalCode}} {{city}}</li>
-							            </ul>
-						            {{/if}}
-					            {{/if}}
-
-					            {{#if region}}
-						            <ul>
-						              <li>Region</li>
-						              <li>{{region}}</li>
-						            </ul>
-											{{/if}}
-
-					          </div>
-					        </div>
-					      </section>
-			      	{{/ifCond}}
-		      	{{/location}}
-		      {{/resume.basics}}
-
-						
-						<!-- LANGUAGE -->
-			      {{#if resume.languages.length}}
-			      <section class="content">
-			        <div class="row">
-			          <div class="content-cat">
-			           Languages
-			          </div>
-			          <div class="content-text">
-
-			          	{{#each resume.languages}}
-				            <ul>
-											
-											{{#if language}}
-				              	<li>{{language}}</li>
-											{{/if}}	
-
-											{{#if fluency}}
-				              <li>{{fluency}}</li>
-											{{/if}}	
-
-				            </ul>
-			            {{/each}}
-
-			          </div>
-			        </div>
-			      </section>
-			      {{/if}}
-
-					{{#resume.basics}}
-			      <!-- PROFILES -->
-			      {{#if profiles.length}}
-				      <section class="content profiles">
-				        <div class="row">
-				          <div class="content-cat">
-				           Profiles
-				          </div>
-				          <div class="content-text profiles-listing">
-				            <ul>
-					            {{#each profiles}}
-					            	{{#if network}}
-					              	<li>
-					              	<a href="{{url}}" target="_blank">
-							                	{{network}}
-							                </a>
-							            </li>
-					              {{/if}}
-					            {{/each}}
-				            </ul>
-				          </div>
-				        </div>
-				      </section>
-			      {{/if}}
-					{{/resume.basics}}
-
-					{{#if resume.work.length}}
-						{{#foreach resume.work}}
-						{{#if $first}}
-								<section class="content">
-						{{else}}
-								<section class="content work-content">
-          	{{/if}}
-			        <div class="row">
-			          <div class="content-cat big-text">
-			          	{{#if $first}}
-											Work	Experience
-			          	{{/if}}
-			          
-								 {{#if startDate}}
-										{{#if endDate}}
-			            		<p>{{startDate}} till {{endDate}}</p>
-			            	{{/if}}
-									{{/if}}
-
-			          </div>
-			          <div class="content-text work-listing education-listing">
-										{{#ifCond company '&&' position}}
-										{{#if $first}}
-					            <p style="margin-top:2.4em;">
-					            {{else}}
-					            <p>
-					          {{/if}}
-					            	{{#if website}}
-													<strong>{{position}}</strong> at <strong><a href="{{website}}">{{company}}:</a></strong>
-												{{else}}
-					            		<strong>{{position}}</strong> at <strong>{{company}}:</strong>
-					            	{{/if}}
-					            </p>
-										{{/ifCond}}
-
-										{{#if summary}}
-											<p>{{summary}}</p>
-										{{/if}}
-
-										{{#if highlights.length}}
-											{{#each highlights}}
-												<p class="highlight">{{.}}</p>
-											{{/each}}
-										{{/if}}
-
-									
-			          </div>
-			        </div>
-			      </section>
-			      {{/foreach}}
-					{{/if}}
-
-					{{#if resume.volunteer.length}}
-						{{#each resume.volunteer}}
-				      <section class="content">
-				        <div class="row">
-				          <div class="content-cat big-text">
-				          {{#if organization}}
-				          	{{organization}}
-				          {{/if}}
-				          
-									{{#if startDate}}
-											{{#if endDate}}
-				            		<p>{{startDate}} till {{endDate}}</p>
-				            	{{/if}}
-										{{/if}}
-
-				          </div>
-				          <div class="content-text work-listing">
-										
-										{{#if summary}}
-					            <p>
-					            	{{summary}}
-					            </p>
-										{{/if}}
-
-										{{#if highlights.length}}
-											{{#each highlights}}
-												<p class="highlight">{{.}}</p>
-											{{/each}}
-										{{/if}}
-				          </div>
-				        </div>
-				      </section>
-			      {{/each}}
-					{{/if}}
-					
-
-					{{#if resume.education.length}}
-						{{#foreach resume.education}}
-							{{#if $first}}
-								<section class="content">
-							{{else}}
-								<section class="content education-content">
-							{{/if}}
-				        <div class="row">
-				          <div class="content-cat big-text">
-
-				          	{{#if $first}}
-				            	Education
-										{{/if}}
-
-										{{#if startDate}}
-											{{#if endDate}}
-				            		<p>{{startDate}} till {{endDate}}</p>
-				            	{{/if}}
-										{{/if}}
-
-				          </div>
-				          <div class="content-text work-listing education-listing">
-										{{#if institution}}
-											{{#if $first}}
-						            <p class="heading" style="margin-top:2.35em;">{{institution}}</p>
-						            {{else}}
-						            <p class="heading">{{institution}}</p>
-						          {{/if}}
-										{{/if}}
-
-										{{#if area}}
-											{{#if gpa}}
-				            		<p class="highlight">
-				            		{{#if studyType}}
-													{{studyType}}:
-				            		{{/if}}
-				            		<i>{{area}} ({{gpa}})</i>
-				            		</p>
-				            	{{/if}}
-										{{/if}}
-
-				          </div>
-				        </div>
-				      </section>
-			      {{/foreach}}
-		      {{/if}}
-
-					{{#if resume.awards.length}}
-						{{#foreach resume.awards}}
-				      <section class="content">
-				        <div class="row">
-				          <div class="content-cat big-text">
-				            {{#if $first}}
-				            	Awards
-										{{/if}}
-
-										{{#if title}}
-				            	<p>{{title}}</p>
-										{{/if}}
-
-										{{#if date}}
-				            	<p style="margin-top:0.25em;">{{date}}</p>
-										{{/if}}
-
-				          </div>
-				          <div class="content-text work-listing">
-
-										{{#if awarder}}
-					         		<strong><p class="heading">{{awarder}}</p></strong>
-										{{/if}}
-
-										{{#if summary}}
-				            	<p class="highlight">{{summary}}</p>
-										{{/if}}
-				          </div>
-				        </div>
-				      </section>
-			      {{/foreach}}
-		      {{/if}}
-
-					{{#if resume.skills.length}}
-			      <section class="content">
-			        <div class="row">
-			          <div class="content-cat">
-			            Skills
-			          </div>
-			          <div class="content-text skills-listing">
-			          	{{#foreach resume.skills}}
-			            	<p>
-			            	<span class="name">
-			              {{#if name}}
-											<strong>
-											{{name}}{{#if level}}{{else}}:{{/if}}
-
-											</strong>
-			            	{{/if}}
-			            	</span>
-
-										{{#if level}}
-		                	<span>({{level}}):</span>
-		                {{/if}}
-
-											{{#if keywords.length}}
-												{{#commalist keywords}}{{.}}{{/commalist}}
-											{{/if}}
-			            	</p>
-			            {{/foreach}}
-			          </div>
-			        </div>
-			      </section>
-		    	{{/if}}
-
-		    	{{#if resume.interests.length}}
-			      <section class="content">
-			        <div class="row">
-			          <div class="content-cat">
-			            Interests
-			          </div>
-			          <div class="content-text skills-listing">
-			          	{{#foreach resume.interests}}
-			            	<p>
-			            	<span class="name">
-			              {{#if name}}
-											<strong>
-												{{name}}:
-											</strong>
-			            	{{/if}}
-			            	</span>
-											{{#if keywords.length}}
-												{{#commalist keywords}}{{.}}{{/commalist}}
-											{{/if}}
-			            	</p>
-			            {{/foreach}}
-			          </div>
-			        </div>
-			      </section>
-		    	{{/if}}
-
-		    </div>
-		      
-		  </article>
-		  
-		</div>
-	</body>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, user-scalable=no, minimal-ui">
+  <title>{{#resume.basics}}{{name}}{{/resume.basics}}</title>
+  <link href='http://fonts.googleapis.com/css?family=Merriweather:400,300,700' rel='stylesheet' type='text/css'>
+  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
+  <style>{{{css}}}</style>
+  <style media="print">{{{print}}}</style>
+</head>
+<body>
+  <div class="resume-wrapper">
+    <article class="paper">
+      {{#resume.basics}}
+        <header>
+          <div class="header-content">
+            {{#if picture}}
+              <div class="header-pic">
+                <img src="{{picture}}" class="pic" />
+              </div>
+            {{/if}}
+            <div class="header-text">
+              <p>
+                {{name}}
+              </p>
+              <p class="subtitle">{{label}}</p>
+            </div>
+          </div>
+        </header>
+        <div class="content-wrapper">
+          <!-- CONTACT -->
+          <section class="content">
+            <div class="row">
+              <div class="content-cat">
+                Contact
+              </div>
+              <div class="content-text">
+                {{#if website}}
+                  <ul>
+                    <li>Website</li>
+                    <li>{{website}}</li>
+                  </ul>
+                {{/if}}
+                {{#if email}}
+                  <ul>
+                    <li>Email</li>
+                    <li>{{email}}</li>
+                  </ul>
+                {{/if}}
+                {{#if phone}}
+                  <ul>
+                    <li>Phone</li>
+                    <li>{{phone}}</li>
+                  </ul>
+                {{/if}}
+              </div>
+            </div>
+          </section>
+          <!-- LOCATION -->
+          {{#location}}
+            {{#ifCond address '||' city}}
+              <section class="content">
+                <div class="row">
+                  <div class="content-cat">
+                    Location
+                  </div>
+                  <div class="content-text">
+                    {{#if address}}
+                      <ul>
+                        <li>Address</li>
+                        <li>{{address}}</li>
+                      </ul>
+                    {{/if}}
+                    {{#if city}}
+                      {{#if postalCode}}
+                        <ul>
+                          <li>Postal Code & City</li>
+                          <li>{{postalCode}} {{city}}</li>
+                        </ul>
+                      {{/if}}
+                    {{/if}}
+                    {{#if region}}
+                      <ul>
+                        <li>Region</li>
+                        <li>{{region}}</li>
+                      </ul>
+                    {{/if}}
+                  </div>
+                </div>
+              </section>
+            {{/ifCond}}
+          {{/location}}
+      {{/resume.basics}}
+        <!-- LANGUAGE -->
+          {{#if resume.languages.length}}
+            <section class="content">
+              <div class="row">
+                <div class="content-cat">
+                  Languages
+                </div>
+                <div class="content-text">
+                  {{#each resume.languages}}
+                    <ul>
+                      {{#if language}}
+                        <li>{{language}}</li>
+                      {{/if}}
+                      {{#if fluency}}
+                        <li>{{fluency}}</li>
+                      {{/if}}
+                    </ul>
+                  {{/each}}
+                </div>
+              </div>
+            </section>
+          {{/if}}
+          {{#resume.basics}}
+            <!-- PROFILES -->
+            {{#if profiles.length}}
+              <section class="content profiles">
+                <div class="row">
+                  <div class="content-cat">
+                    Profiles
+                  </div>
+                  <div class="content-text profiles-listing">
+                    <ul>
+                      {{#each profiles}}
+                        {{#if network}}
+                          <li>
+                            <a href="{{url}}" target="_blank">
+                              {{network}}
+                            </a>
+                          </li>
+                        {{/if}}
+                      {{/each}}
+                    </ul>
+                  </div>
+                </div>
+              </section>
+            {{/if}}
+          {{/resume.basics}}
+          {{#if resume.work.length}}
+            {{#foreach resume.work}}
+              {{#if $first}}
+                <section class="content">
+              {{else}}
+                <section class="content work-content">
+              {{/if}}
+                  <div class="row">
+                    <div class="content-cat big-text">
+                      {{#if $first}}
+                        Work  Experience
+                      {{/if}}
+                      {{#if startDate}}
+                        {{#if endDate}}
+                          <p>{{startDate}} till {{endDate}}</p>
+                        {{/if}}
+                      {{/if}}
+                    </div>
+                    <div class="content-text work-listing education-listing">
+                      {{#ifCond company '||' position}}
+                        {{#if $first}}
+                          <p style="margin-top:2.4em;">
+                        {{else}}
+                          <p>
+                        {{/if}}
+                        {{#if website}}
+                          <strong>{{position}}</strong>
+                          {{#if company.length}} at <strong><a href="{{website}}">{{company}}:</a></strong> {{/if}}
+                        {{else}}
+                          <strong>{{position}}</strong>
+                          {{#if company.length}} at <strong>{{company}}:</strong> {{/if}}
+                        {{/if}}
+                        </p>
+                      {{/ifCond}}
+                      {{#if summary}}
+                        <p>{{summary}}</p>
+                      {{/if}}
+                      {{#if highlights.length}}
+                        {{#each highlights}}
+                          <p class="highlight">{{.}}</p>
+                        {{/each}}
+                      {{/if}}
+                    </div>
+                  </div>
+                </section>
+            {{/foreach}}
+          {{/if}}
+          {{#if resume.volunteer.length}}
+            {{#each resume.volunteer}}
+              <section class="content">
+                <div class="row">
+                  <div class="content-cat big-text">
+                    {{#if organization}}
+                      {{organization}}
+                    {{/if}}
+                    {{#if startDate}}
+                      {{#if endDate}}
+                        <p>{{startDate}} till {{endDate}}</p>
+                      {{/if}}
+                    {{/if}}
+                  </div>
+                  <div class="content-text work-listing">
+                    {{#if summary}}
+                      <p>
+                        {{summary}}
+                      </p>
+                    {{/if}}
+                    {{#if highlights.length}}
+                      {{#each highlights}}
+                        <p class="highlight">{{.}}</p>
+                      {{/each}}
+                    {{/if}}
+                  </div>
+                </div>
+              </section>
+            {{/each}}
+          {{/if}}
+          {{#if resume.education.length}}
+            {{#foreach resume.education}}
+              {{#if $first}}
+                <section class="content">
+              {{else}}
+                <section class="content education-content">
+              {{/if}}
+                  <div class="row">
+                    <div class="content-cat big-text">
+                      {{#if $first}}
+                        Education
+                      {{/if}}
+                      {{#if startDate}}
+                        {{#if endDate}}
+                          <p>{{startDate}} till {{endDate}}</p>
+                        {{/if}}
+                      {{/if}}
+                    </div>
+                    <div class="content-text work-listing education-listing">
+                      {{#if institution}}
+                        {{#if $first}}
+                          <p class="heading" style="margin-top:2.35em;">{{institution}}</p>
+                        {{else}}
+                          <p class="heading">{{institution}}</p>
+                        {{/if}}
+                      {{/if}}
+                      {{#if area}}
+                        {{#if gpa}}
+                        <p class="highlight">
+                          {{#if studyType}}
+                          {{studyType}}:
+                          {{/if}}
+                          <i>{{area}} ({{gpa}})</i>
+                        </p>
+                        {{/if}}
+                      {{/if}}
+                    </div>
+                  </div>
+                </section>
+            {{/foreach}}
+          {{/if}}
+          {{#if resume.awards.length}}
+            {{#foreach resume.awards}}
+              <section class="content">
+                <div class="row">
+                  <div class="content-cat big-text">
+                    {{#if $first}}
+                      Awards
+                    {{/if}}
+                    {{#if title}}
+                      <p>{{title}}</p>
+                    {{/if}}
+                    {{#if date}}
+                      <p style="margin-top:0.25em;">{{date}}</p>
+                    {{/if}}
+                  </div>
+                  <div class="content-text work-listing">
+                    {{#if awarder}}
+                      <strong><p class="heading">{{awarder}}</p></strong>
+                    {{/if}}
+                    {{#if summary}}
+                      <p class="highlight">{{summary}}</p>
+                    {{/if}}
+                  </div>
+                </div>
+              </section>
+            {{/foreach}}
+          {{/if}}
+          {{#if resume.skills.length}}
+          <section class="content">
+            <div class="row">
+              <div class="content-cat">
+                Skills
+              </div>
+              <div class="content-text skills-listing">
+                {{#foreach resume.skills}}
+                  <p>
+                    <span class="name">
+                      {{#if name}}
+                        <strong>
+                          {{name}}{{#if level}}{{else}}:{{/if}}
+                        </strong>
+                      {{/if}}
+                    </span>
+                    {{#if level}}
+                      <span>({{level}}):</span>
+                    {{/if}}
+                    {{#if keywords.length}}
+                      {{#commalist keywords}}{{.}}{{/commalist}}
+                    {{/if}}
+                  </p>
+                {{/foreach}}
+              </div>
+            </div>
+          </section>
+          {{/if}}
+          {{#if resume.interests.length}}
+            <section class="content">
+              <div class="row">
+                <div class="content-cat">
+                  Interests
+                </div>
+                <div class="content-text skills-listing">
+                  {{#foreach resume.interests}}
+                    <p>
+                      <span class="name">
+                        {{#if name}}
+                          <strong>
+                            {{name}}:
+                          </strong>
+                        {{/if}}
+                      </span>
+                      {{#if keywords.length}}
+                        {{#commalist keywords}}{{.}}{{/commalist}}
+                      {{/if}}
+                    </p>
+                  {{/foreach}}
+                </div>
+              </div>
+            </section>
+          {{/if}}
+        </div>
+    </article>
+  </div>
+</body>
 </html>


### PR DESCRIPTION
Fixes massive whitespace damage throughout the sources and adds some comments in `index.js`.

Visible changes:
* The rendering of work listings is a little more flexible and now renders correctly if the company field is omitted (useful for freelance positions). For example, where an empty `company` field with a `position` field of `'Freelance Front-End Dev'` previously would have rendered something like "**Freelance Front-End Dev** at :", it now renders simply as "**Freelance Front-End Dev:**" The relevant modifications are in `resume.template` at the (new version) lines `169` and `172`
* The header picture no longer has title "Wiggle Wiggle"


Cheers!