### PR TITLE
css: Avoid page break inside work and education content

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -276,6 +276,7 @@ div.content-text.work-listing.education-listing > p:nth-child(2) {
 
 .work-content, .education-content {
   padding-top: .75em;
+  page-break-inside: avoid;
 }
 
 section.content.education-content > div > div.content-cat {


### PR DESCRIPTION
Breaks now appear before the next section
Signed-off-by: Nicholas Capo <nicholas.capo@gmail.com>